### PR TITLE
feat: replace use of environment variable `GITHUB_SHA` for argument `--commit-sha`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -91,7 +91,7 @@ pub fn get_closest_tag() -> Result<String, Error> {
     Ok(String::from(stdout.strip_suffix('\n').unwrap()))
 }
 
-pub fn get_tag_commit_sha(tag: &String) -> Result<String, Error> {
+pub fn get_tag_commit_sha(tag: &str) -> Result<String, Error> {
     let output_result = Command::new("git")
         .arg("rev-list")
         .args(["-n", "1"])
@@ -124,10 +124,7 @@ pub fn get_tag_commit_sha(tag: &String) -> Result<String, Error> {
     Ok(String::from(stdout.strip_suffix('\n').unwrap()))
 }
 
-pub fn get_commit_messages(
-    from_commit: &String,
-    until_commit: &String,
-) -> Result<Vec<String>, Error> {
+pub fn get_commit_messages(from_commit: &str, until_commit: &str) -> Result<Vec<String>, Error> {
     let output_result = Command::new("git")
         .arg("log")
         .arg("--format=%s")
@@ -163,7 +160,7 @@ pub fn get_commit_messages(
     Ok(stdout.lines().map(|s| s.to_owned()).collect())
 }
 
-pub fn create_tag(tag: &String, tag_message: &String) -> Result<(), Error> {
+pub fn create_tag(tag: &str, tag_message: &str) -> Result<(), Error> {
     let output_result = Command::new("git")
         .arg("tag")
         .args(["-a", tag])

--- a/src/source/git.rs
+++ b/src/source/git.rs
@@ -28,7 +28,7 @@ impl SourceActions for GitSource {
         Ok(&self.commit_messages)
     }
 
-    fn fetch_from_commit(&mut self, sha: &String) -> Result<(), Error> {
+    fn fetch_from_commit(&mut self, sha: &str) -> Result<(), Error> {
         self.closest_tag = match git::get_closest_tag() {
             Ok(tag) => tag,
             Err(error) => return Err(error),
@@ -39,7 +39,7 @@ impl SourceActions for GitSource {
             Err(error) => return Err(error),
         };
 
-        self.commit_messages = match git::get_commit_messages(&self.closest_tag_commit_sha, &sha) {
+        self.commit_messages = match git::get_commit_messages(&self.closest_tag_commit_sha, sha) {
             Ok(commit_messages) => commit_messages,
             Err(error) => return Err(error),
         };

--- a/src/source/git.rs
+++ b/src/source/git.rs
@@ -28,7 +28,7 @@ impl SourceActions for GitSource {
         Ok(&self.commit_messages)
     }
 
-    fn fetch_from_commit(&mut self, sha: String) -> Result<(), Error> {
+    fn fetch_from_commit(&mut self, sha: &String) -> Result<(), Error> {
         self.closest_tag = match git::get_closest_tag() {
             Ok(tag) => tag,
             Err(error) => return Err(error),

--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -35,7 +35,7 @@ impl GithubSource {
 }
 
 impl SourceActions for GithubSource {
-    fn fetch_from_commit(&mut self, sha: String) -> Result<(), Error> {
+    fn fetch_from_commit(&mut self, sha: &String) -> Result<(), Error> {
         let tags = match get_tags(&self.repo_id, &self.token)? {
             Some(tags) => tags,
             None => return Err(Error::new(ErrorKind::MissingGitTags, None)),

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -8,7 +8,7 @@ pub mod github;
 pub trait SourceActions {
     fn get_commit_messages(&self) -> Result<&Vec<String>, Error>;
     fn get_closest_tag(&self) -> Result<&String, Error>;
-    fn fetch_from_commit(&mut self, sha: String) -> Result<(), Error>;
+    fn fetch_from_commit(&mut self, sha: &String) -> Result<(), Error>;
 }
 
 #[enum_dispatch(SourceActions)]

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -8,7 +8,7 @@ pub mod github;
 pub trait SourceActions {
     fn get_commit_messages(&self) -> Result<&Vec<String>, Error>;
     fn get_closest_tag(&self) -> Result<&String, Error>;
-    fn fetch_from_commit(&mut self, sha: &String) -> Result<(), Error>;
+    fn fetch_from_commit(&mut self, sha: &str) -> Result<(), Error>;
 }
 
 #[enum_dispatch(SourceActions)]


### PR DESCRIPTION
As mentioned in #21, I am not particularly happy with the behavior obtained by using `GITHUB_SHA` out of the box so I removed that functionality and replaced it with the argument `--commit-sha`. 
Now, using the git source, you can use the new argument to calculate version bumps not only from the current commit but also from the one specified in the argument, which seems interesting.