### PR TITLE
refactor: add pagination to tag obtaintion from GitHub REST API

### DIFF
--- a/src/source/github.rs
+++ b/src/source/github.rs
@@ -324,7 +324,7 @@ fn get_all_tags(repo_id: &String, token: &Option<String>) -> Vec<GithubTag> {
         tags.extend(t);
         page += 1;
     }
-    return tags;
+    tags
 }
 
 /// Obtains commits from the given `sha` using the GitHub REST API. If `token` is given, the requests will be authorized.


### PR DESCRIPTION
Instead of adding an iterator like mentioned in #23, we are obtaining all tags using pagination to avoid failing if the oldest closest tag is not found in the latest 100 tags.